### PR TITLE
#9 API周りのテストコードを追加

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		344E4062279DAD1F006B1B71 /* RepositoryCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344E4061279DAD1F006B1B71 /* RepositoryCodableTests.swift */; };
+		344E4069279DB7FA006B1B71 /* RepositoryAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344E4068279DB7FA006B1B71 /* RepositoryAPITests.swift */; };
+		344E406B279DBBC5006B1B71 /* DataUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344E406A279DBBC5006B1B71 /* DataUtility.swift */; };
+		344E406D279DBD03006B1B71 /* Repository.json in Resources */ = {isa = PBXBuildFile; fileRef = 344E406C279DBD03006B1B71 /* Repository.json */; };
 		34584A2A279B0353007882AD /* RepositoryCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34584A29279B0353007882AD /* RepositoryCodable.swift */; };
 		34584A2C279B0E9B007882AD /* SearchResultCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34584A2B279B0E9B007882AD /* SearchResultCodable.swift */; };
 		34584A2E279B0F01007882AD /* OwnerCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34584A2D279B0F01007882AD /* OwnerCodable.swift */; };
@@ -51,6 +55,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		344E4061279DAD1F006B1B71 /* RepositoryCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryCodableTests.swift; sourceTree = "<group>"; };
+		344E4068279DB7FA006B1B71 /* RepositoryAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryAPITests.swift; sourceTree = "<group>"; };
+		344E406A279DBBC5006B1B71 /* DataUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataUtility.swift; sourceTree = "<group>"; };
+		344E406C279DBD03006B1B71 /* Repository.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Repository.json; sourceTree = "<group>"; };
 		34584A29279B0353007882AD /* RepositoryCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryCodable.swift; sourceTree = "<group>"; };
 		34584A2B279B0E9B007882AD /* SearchResultCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultCodable.swift; sourceTree = "<group>"; };
 		34584A2D279B0F01007882AD /* OwnerCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OwnerCodable.swift; sourceTree = "<group>"; };
@@ -130,6 +138,15 @@
 			path = Pods;
 			sourceTree = "<group>";
 		};
+		344E4063279DAD9F006B1B71 /* TestJSON */ = {
+			isa = PBXGroup;
+			children = (
+				344E406A279DBBC5006B1B71 /* DataUtility.swift */,
+				344E406C279DBD03006B1B71 /* Repository.json */,
+			);
+			path = TestJSON;
+			sourceTree = "<group>";
+		};
 		34584A28279B0294007882AD /* Codable */ = {
 			isa = PBXGroup;
 			children = (
@@ -143,6 +160,7 @@
 		34584A31279BD653007882AD /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				344E4063279DAD9F006B1B71 /* TestJSON */,
 				34584A3B279BF26B007882AD /* API */,
 				34584A28279B0294007882AD /* Codable */,
 				34584A37279BDCFB007882AD /* SearchResultSectionModel.swift */,
@@ -266,6 +284,8 @@
 			children = (
 				BFD945F5244DC5EB0012785A /* iOSEngineerCodeCheckTests.swift */,
 				BFD945F7244DC5EB0012785A /* Info.plist */,
+				344E4061279DAD1F006B1B71 /* RepositoryCodableTests.swift */,
+				344E4068279DB7FA006B1B71 /* RepositoryAPITests.swift */,
 			);
 			path = iOSEngineerCodeCheckTests;
 			sourceTree = "<group>";
@@ -391,6 +411,7 @@
 			files = (
 				BFD945EB244DC5EB0012785A /* LaunchScreen.storyboard in Resources */,
 				34584A42279D7EEA007882AD /* SearchView.storyboard in Resources */,
+				344E406D279DBD03006B1B71 /* Repository.json in Resources */,
 				BFD945E8244DC5EB0012785A /* Assets.xcassets in Resources */,
 				34584A46279D7F7C007882AD /* DetailView.storyboard in Resources */,
 			);
@@ -547,6 +568,7 @@
 				34584A4C279D8B74007882AD /* APIUtility.swift in Sources */,
 				34584A2E279B0F01007882AD /* OwnerCodable.swift in Sources */,
 				34584A2A279B0353007882AD /* RepositoryCodable.swift in Sources */,
+				344E406B279DBBC5006B1B71 /* DataUtility.swift in Sources */,
 				BF0A658D244F2A3B00280FA6 /* DetailViewController.swift in Sources */,
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,
 				34584A3D279D446B007882AD /* DetailViewModel.swift in Sources */,
@@ -559,6 +581,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				344E4069279DB7FA006B1B71 /* RepositoryAPITests.swift in Sources */,
+				344E4062279DAD1F006B1B71 /* RepositoryCodableTests.swift in Sources */,
 				BFD945F6244DC5EB0012785A /* iOSEngineerCodeCheckTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iOSEngineerCodeCheck/Model/TestJSON/DataUtility.swift
+++ b/iOSEngineerCodeCheck/Model/TestJSON/DataUtility.swift
@@ -1,0 +1,22 @@
+//
+//  DataUtility.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by 肥沼英里 on 2022/01/24.
+//  Copyright © 2022 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+class DataUtility {
+    
+    static func loadJson(filename: String) -> Data? {
+        guard let url = Bundle.main.url(forResource: filename, withExtension: "json") else {
+            return nil
+        }
+        guard let data = try? Data(contentsOf: url) else {
+            return nil
+        }
+        return data
+    }
+}

--- a/iOSEngineerCodeCheck/Model/TestJSON/Repository.json
+++ b/iOSEngineerCodeCheck/Model/TestJSON/Repository.json
@@ -1,0 +1,31 @@
+[{
+    "full_name": "nvdla/sw",
+    "language": "C++",
+    "stargazers_count": 386,
+    "watchers_count": 386,
+    "forks_count": 156,
+    "open_issues_count": 149,
+    "owner": {
+        "avatar_url": "https://avatars.githubusercontent.com/u/32145751?v=4"
+    }
+}, {
+    "full_name": "courses-ionio/sw",
+    "language": null,
+    "stargazers_count": 14,
+    "watchers_count": 372,
+    "forks_count": 372,
+    "open_issues_count": 1,
+    "owner": {
+        "avatar_url": "https://avatars.githubusercontent.com/u/10682852?v=4"
+    }
+}, {
+    "full_name": "yona-projects/yona",
+    "language": "JavaScript",
+    "stargazers_count": 434,
+    "watchers_count": 434,
+    "forks_count": 209,
+    "open_issues_count": 1,
+    "owner": {
+        "avatar_url": "https://avatars.githubusercontent.com/u/16770912?v=4"
+    }
+}]

--- a/iOSEngineerCodeCheckTests/RepositoryAPITests.swift
+++ b/iOSEngineerCodeCheckTests/RepositoryAPITests.swift
@@ -1,0 +1,65 @@
+//
+//  RepositoryAPITests.swift
+//  iOSEngineerCodeCheckTests
+//
+//  Created by 肥沼英里 on 2022/01/24.
+//  Copyright © 2022 YUMEMI Inc. All rights reserved.
+//
+
+import RxTest
+import RxBlocking
+import RxSwift
+import XCTest
+@testable import iOSEngineerCodeCheck
+
+class RepositoryAPITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}
+
+extension RepositoryAPITests {
+    
+    /// 導通確認
+    func test() {
+        
+        let repositoryAPI = RepositoryAPI.shared
+        
+        let exp = expectation(description: "exp")
+        
+        repositoryAPI.searchRepositories(by: "test") { result in
+            switch result {
+                
+            case .success(_):
+                XCTAssert(true)
+                exp.fulfill()
+                
+            case .failure(let error):
+                print(error.localizedDescription)
+                XCTAssert(false)
+                exp.fulfill()
+            }
+        }
+
+        wait(for: [exp], timeout: 30.0)
+        
+    }
+}

--- a/iOSEngineerCodeCheckTests/RepositoryCodableTests.swift
+++ b/iOSEngineerCodeCheckTests/RepositoryCodableTests.swift
@@ -1,0 +1,69 @@
+//
+//  RepositoryCodableTests.swift
+//  iOSEngineerCodeCheckTests
+//
+//  Created by 肥沼英里 on 2022/01/24.
+//  Copyright © 2022 YUMEMI Inc. All rights reserved.
+//
+
+import XCTest
+@testable import iOSEngineerCodeCheck
+
+class RepositoryCodableTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}
+
+extension RepositoryCodableTests {
+    
+    /// SearchResultの中のRepositoryCodableのJSONデータをCodableにデコードするテスト
+    func testCodables() {
+        
+        guard let data = DataUtility.loadJson(filename: "Repository")
+        else {
+            XCTAssert(false)
+            return
+        }
+        
+        guard let codables = try? JSONDecoder().decode([RepositoryCodable].self, from: data)
+        else{
+            XCTAssert(false)
+            return
+        }
+        
+        guard let repositoryCodable = codables.first
+        else {
+            XCTAssert(false)
+            return
+        }
+        
+        XCTAssertEqual(repositoryCodable.fullName, "nvdla/sw")
+        XCTAssertEqual(repositoryCodable.language, "C++")
+        XCTAssertEqual(repositoryCodable.stargazersCount, 386)
+        XCTAssertEqual(repositoryCodable.watchersCount, 386)
+        XCTAssertEqual(repositoryCodable.forksCount, 156)
+        XCTAssertEqual(repositoryCodable.openIssuesCount, 149)
+        
+        let owner = repositoryCodable.owner
+        XCTAssertEqual(owner.avatarUrl, "https://avatars.githubusercontent.com/u/32145751?v=4")
+    }
+}


### PR DESCRIPTION
## 変更の概要
Closes #9
API周りのテストコードを追加しました。

## 変更内容

- テスト用のRepository.jsonを作成
- Jsonをdataに変えるfunctionを作成
- JsonからCodableにDecodeするテストを作成
- API通信の導通確認をするテストを作成

## 実装で迷った点

RxTest, RxBlockingを用いたテスト方法が調べても理解しきれなかったです。
Quick, Nimbleというライブラリも併用するのが一般的なのでしょうか。
また、テストコードをあまり書いたことがないため最低限のコードしか書くことができませんでした。